### PR TITLE
Starting grpc server -> Started grpc server

### DIFF
--- a/src/protobuf_server/server.rs
+++ b/src/protobuf_server/server.rs
@@ -1,7 +1,6 @@
 use crate::protobuf_server::services::ecdar_backend_server::EcdarBackendServer;
 use crate::protobuf_server::ConcreteEcdarBackend;
 use core::time::Duration;
-use log::info;
 use tokio::runtime;
 use tonic::transport::Server;
 
@@ -26,16 +25,15 @@ async fn start_grpc_server(
     cache_size: usize,
     thread_number: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Starting grpc server on '{}'", ip_endpoint.trim());
-
-    Server::builder()
+    let server = Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(120)))
         .add_service(EcdarBackendServer::new(ConcreteEcdarBackend::new(
             thread_number,
             cache_size,
         )))
-        .serve(ip_endpoint.trim().parse()?)
-        .await?;
+        .serve(ip_endpoint.trim().parse()?);
+    println!("Started grpc server on '{}'\r", ip_endpoint.trim());
 
+    server.await?;
     Ok(())
 }


### PR DESCRIPTION
also changed info to println to avoid the debugger for now

This is needed to make [Ecdar-Test PR](https://github.com/ECDAR-AAU-SW-P5/Ecdar-Test/pull/2) work