### PR TITLE
Clock reduction benchmarking group6

### DIFF
--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -15,23 +15,16 @@ fn bench_clock_reduced_refinement(c: &mut Criterion) {
     let mut group = c.benchmark_group("Clock Reduction");
     group.bench_function("Refinement check - No reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = true;
-        b.iter(|| normal_refinement(&mut loader));
+        b.iter(|| clock_reduction_helper(&mut loader));
     });
     group.bench_function("Refinement check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;
-        b.iter(|| clock_reduced_refinement(&mut loader));
+        b.iter(|| clock_reduction_helper(&mut loader));
     });
     group.finish();
 }
 
-fn clock_reduced_refinement(loader: &mut Box<dyn ComponentLoader>) {
-    let query = parse_to_query(QUERY);
-    create_executable_query(query.get(0).unwrap(), loader.as_mut())
-        .unwrap()
-        .execute();
-}
-
-fn normal_refinement(loader: &mut Box<dyn ComponentLoader>) {
+fn clock_reduction_helper(loader: &mut Box<dyn ComponentLoader>) {
     let query = parse_to_query(QUERY);
     create_executable_query(query.get(0).unwrap(), loader.as_mut())
         .unwrap()

--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -4,13 +4,16 @@ use std::time::Duration;
 
 mod bench_helper;
 use reveaal::extract_system_rep::create_executable_query;
+use reveaal::model_objects::expressions::QueryExpression::Prune;
 use reveaal::parse_queries::parse_to_query;
 
 // const QUERY: &str = "refinement: (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher) <= (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)";
 const REFINEMENT_QUERY: &str = "refinement: Researcher <= Spec // Administration // Machine";
 const REACHABILITY_QUERY: &str = "reachability: Machine || Researcher @ Machine.L5 && Researcher.L6 -> Machine.L4 && Researcher.L9";
-const CONSISTENCY_QUERY: &str = "consistency: Machine";
-const GETCOMPONENT_QUERY: &str = "get-component: Adm2 || Machine save-as test";
+const CONSISTENCY_QUERY: &str = "consistency: Machine || Researcher";
+const SYNTAX_QUERY: &str = "syntax: Researcher";
+const GETCOMPONENT_QUERY: &str = "get-component: Adm2 || Machine save-as get_component_test";
+const DETERMINISM_QUERY: &str = "determinism: Researcher && Machine";
 
 /// This bench runs `REFINEMENT QUERY` with and without clock reduction such that you can compare the results. It also runs other queries
 fn bench_clock_reduction(c: &mut Criterion) {
@@ -33,9 +36,17 @@ fn bench_clock_reduction(c: &mut Criterion) {
         loader.get_settings_mut().disable_clock_reduction = false;
         b.iter(|| clock_reduction_helper(&mut loader, CONSISTENCY_QUERY));
     });
+    group.bench_function("Syntax check - With reduction", |b| {
+        loader.get_settings_mut().disable_clock_reduction = false;
+        b.iter(|| clock_reduction_helper(&mut loader, SYNTAX_QUERY));
+    });
     group.bench_function("GetComponent check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;
         b.iter(|| clock_reduction_helper(&mut loader, GETCOMPONENT_QUERY));
+    });
+    group.bench_function("Determinism check - With reduction", |b| {
+        loader.get_settings_mut().disable_clock_reduction = false;
+        b.iter(|| clock_reduction_helper(&mut loader, DETERMINISM_QUERY));
     });
 
     group.finish();
@@ -50,7 +61,7 @@ fn clock_reduction_helper(loader: &mut Box<dyn ComponentLoader>, input: &str) {
 
 criterion_group! {
     name = clock_reduction_bench;
-    config = Criterion::default().sample_size(10).warm_up_time(Duration::new(10,0));
+    config = Criterion::default().sample_size(10);
     targets = bench_clock_reduction
 }
 criterion_main!(clock_reduction_bench);

--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use reveaal::ComponentLoader;
+use std::time::Duration;
 
 mod bench_helper;
 use reveaal::extract_system_rep::create_executable_query;
@@ -26,11 +26,11 @@ fn bench_clock_reduction(c: &mut Criterion) {
     });
     group.bench_function("Reachability check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;
-        b.iter(|| clock_reduction_helper(&mut loader,REACHABILITY_QUERY));
+        b.iter(|| clock_reduction_helper(&mut loader, REACHABILITY_QUERY));
     });
     group.bench_function("Consistency check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;
-        b.iter(|| clock_reduction_helper(&mut loader,CONSISTENCY_QUERY));
+        b.iter(|| clock_reduction_helper(&mut loader, CONSISTENCY_QUERY));
     });
     group.bench_function("GetComponent check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;

--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use reveaal::ComponentLoader;
 
@@ -5,27 +6,42 @@ mod bench_helper;
 use reveaal::extract_system_rep::create_executable_query;
 use reveaal::parse_queries::parse_to_query;
 
-const QUERY: &str = "refinement: (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher) <= (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)";
+const REFINEMENT_QUERY: &str = "refinement: Researcher <= Spec // Administration // Machine";
+const REACHABILITY_QUERY: &str = "reachability: Machine || Researcher @ Machine.L5 && Researcher.L6 -> Machine.L4 && Researcher.L9";
+const CONSISTENCY_QUERY: &str = "consistency: Machine";
+const GETCOMPONENT_QUERY: &str = "get-component: Adm2 || Machine save-as test";
 
-/// This bench runs `QUERY` with and without clock reduction such that you can compare the results.
-/// The bench takes about 40 min on my machine, so grab some coffee.
-fn bench_clock_reduced_refinement(c: &mut Criterion) {
+/// This bench runs `REFINEMENT QUERY` with and without clock reduction such that you can compare the results. It also runs other queries
+fn bench_clock_reduction(c: &mut Criterion) {
     // Set up the bench.
     let mut loader = bench_helper::get_uni_loader();
     let mut group = c.benchmark_group("Clock Reduction");
     group.bench_function("Refinement check - No reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = true;
-        b.iter(|| clock_reduction_helper(&mut loader));
+        b.iter(|| clock_reduction_helper(&mut loader, REFINEMENT_QUERY));
     });
     group.bench_function("Refinement check - With reduction", |b| {
         loader.get_settings_mut().disable_clock_reduction = false;
-        b.iter(|| clock_reduction_helper(&mut loader));
+        b.iter(|| clock_reduction_helper(&mut loader, REFINEMENT_QUERY));
     });
+    group.bench_function("Reachability check - With reduction", |b| {
+        loader.get_settings_mut().disable_clock_reduction = false;
+        b.iter(|| clock_reduction_helper(&mut loader,REACHABILITY_QUERY));
+    });
+    group.bench_function("Consistency check - With reduction", |b| {
+        loader.get_settings_mut().disable_clock_reduction = false;
+        b.iter(|| clock_reduction_helper(&mut loader,CONSISTENCY_QUERY));
+    });
+    group.bench_function("GetComponent check - With reduction", |b| {
+        loader.get_settings_mut().disable_clock_reduction = false;
+        b.iter(|| clock_reduction_helper(&mut loader, GETCOMPONENT_QUERY));
+    });
+
     group.finish();
 }
 
-fn clock_reduction_helper(loader: &mut Box<dyn ComponentLoader>) {
-    let query = parse_to_query(QUERY);
+fn clock_reduction_helper(loader: &mut Box<dyn ComponentLoader>, input: &str) {
+    let query = parse_to_query(input);
     create_executable_query(query.get(0).unwrap(), loader.as_mut())
         .unwrap()
         .execute();
@@ -33,7 +49,7 @@ fn clock_reduction_helper(loader: &mut Box<dyn ComponentLoader>) {
 
 criterion_group! {
     name = clock_reduction_bench;
-    config = Criterion::default().sample_size(10);
-    targets = bench_clock_reduced_refinement
+    config = Criterion::default().sample_size(10).warm_up_time(Duration::new(10,0));
+    targets = bench_clock_reduction
 }
 criterion_main!(clock_reduction_bench);

--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -6,6 +6,7 @@ mod bench_helper;
 use reveaal::extract_system_rep::create_executable_query;
 use reveaal::parse_queries::parse_to_query;
 
+// const QUERY: &str = "refinement: (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher) <= (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)";
 const REFINEMENT_QUERY: &str = "refinement: Researcher <= Spec // Administration // Machine";
 const REACHABILITY_QUERY: &str = "reachability: Machine || Researcher @ Machine.L5 && Researcher.L6 -> Machine.L4 && Researcher.L9";
 const CONSISTENCY_QUERY: &str = "consistency: Machine";

--- a/benches/clock_reduction_bench.rs
+++ b/benches/clock_reduction_bench.rs
@@ -1,10 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use reveaal::ComponentLoader;
-use std::time::Duration;
 
 mod bench_helper;
 use reveaal::extract_system_rep::create_executable_query;
-use reveaal::model_objects::expressions::QueryExpression::Prune;
 use reveaal::parse_queries::parse_to_query;
 
 // const QUERY: &str = "refinement: (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher) <= (((((Adm2 && HalfAdm1 && HalfAdm2) || Machine || Researcher) && ((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher) && (Adm2 || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)";

--- a/src/data_reader/xml_parser.rs
+++ b/src/data_reader/xml_parser.rs
@@ -13,7 +13,10 @@ use std::io::Read;
 use std::path::Path;
 
 pub fn is_xml_project<P: AsRef<Path>>(project_path: P) -> bool {
-    project_path.as_ref().ends_with(".xml")
+    project_path
+        .as_ref()
+        .extension()
+        .is_some_and(|ext| ext == "xml")
 }
 
 ///Used to parse systems described in xml

--- a/src/transition_systems/transition_id.rs
+++ b/src/transition_systems/transition_id.rs
@@ -104,8 +104,8 @@ impl TransitionID {
                 paths[component_index].push(
                     transition
                         .iter()
+                        .filter(|&id| !matches!(id, TransitionID::None))
                         .cloned()
-                        .filter(|id| !matches!(id, TransitionID::None))
                         .collect(),
                 );
             }


### PR DESCRIPTION
Extended the benchmark for clock reduction to benchmark performance on multiple types of query expressions. This will be used to test the efficacy of the clock reduction that we are implementing on both Component and TransitionSystem. 