### PR TITLE
Reference counting locationtree statepair group4

### DIFF
--- a/src/data_reader/proto_reader.rs
+++ b/src/data_reader/proto_reader.rs
@@ -165,7 +165,7 @@ mod tests {
 
     fn assert_state_equals(state1: &State, state2: &State) {
         assert!(
-            state1.zone_ref().equals(state2.zone_ref()),
+            state1.ref_zone().equals(state2.ref_zone()),
             "Zones are not equal"
         );
         assert_eq!(

--- a/src/data_reader/proto_reader.rs
+++ b/src/data_reader/proto_reader.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::rc::Rc;
 
 use edbm::util::constraints::{Conjunction, Constraint, Disjunction, Inequality, RawInequality};
 use edbm::zones::OwnedFederation;
@@ -81,7 +82,7 @@ pub fn proto_state_to_state(state: ProtoState, system: &TransitionSystemPtr) -> 
 fn proto_location_tree_to_location_tree(
     location_tree: ProtoLocationTree,
     system: &TransitionSystemPtr,
-) -> LocationTree {
+) -> Rc<LocationTree> {
     let target: SpecificLocation = location_tree.into();
 
     system.construct_location_tree(target).unwrap()
@@ -216,7 +217,7 @@ mod tests {
                 return;
             }
             for action in system.get_actions() {
-                for t in system.next_transitions(&state.decorated_locations, &action) {
+                for t in system.next_transitions(Rc::clone(&state.decorated_locations), &action) {
                     let state = t.use_transition_alt(state);
                     if let Some(state) = state {
                         let next_state = convert_to_proto_and_back(&state, system);

--- a/src/data_reader/xml_parser.rs
+++ b/src/data_reader/xml_parser.rs
@@ -13,7 +13,10 @@ use std::io::Read;
 use std::path::Path;
 
 pub fn is_xml_project<P: AsRef<Path>>(project_path: P) -> bool {
-    project_path.as_ref().ends_with(".xml")
+    project_path
+        .as_ref()
+        .extension()
+        .is_some_and(|ext| ext == "xml")
 }
 
 ///Used to parse systems described in xml

--- a/src/model_objects/decision.rs
+++ b/src/model_objects/decision.rs
@@ -47,7 +47,7 @@ impl Decision {
         // Intersect the state zone with the allowed zone
         state.update_zone(|zone| zone.intersection(&allowed));
         // Check if the new state is empty
-        if !state.zone_ref().is_empty() {
+        if !state.ref_zone().is_empty() {
             let next_state = transition.use_transition_alt(&state).expect(
                 "If the allowed zone is non-empty, the transition should lead to a non-empty state",
             );

--- a/src/model_objects/decision.rs
+++ b/src/model_objects/decision.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::model_objects::{State, Transition};
 use crate::transition_systems::TransitionSystemPtr;
 
@@ -16,7 +18,8 @@ impl Decision {
     /// # Panics
     /// Panics if the [`Decision`] leads to no new states or is ambiguous (leads to multiple new states)
     pub fn resolve(&self, system: &TransitionSystemPtr) -> Vec<Decision> {
-        let transitions = system.next_transitions(&self.state.decorated_locations, &self.action);
+        let transitions =
+            system.next_transitions(Rc::clone(&self.state.decorated_locations), &self.action);
         let mut next_states: Vec<_> = transitions
             .into_iter()
             .filter_map(|transition| transition.use_transition_alt(&self.state))
@@ -64,7 +67,8 @@ impl Decision {
         let mut next_decisions = vec![];
 
         for action in system.get_actions() {
-            let possible_transitions = system.next_transitions(&state.decorated_locations, &action);
+            let possible_transitions =
+                system.next_transitions(Rc::clone(&state.decorated_locations), &action);
             for t in possible_transitions {
                 if let Some(decision) = Decision::from_state_transition(state.clone(), &t, &action)
                 {

--- a/src/model_objects/state.rs
+++ b/src/model_objects/state.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::transition_systems::{LocationTree, TransitionSystem};
 use edbm::util::bounds::Bounds;
 use edbm::util::constraints::ClockIndex;
@@ -8,12 +10,12 @@ use edbm::zones::OwnedFederation;
 // This should probably be refactored as it causes unnecessary confusion
 #[derive(Clone, Debug)]
 pub struct State {
-    pub decorated_locations: LocationTree,
+    pub decorated_locations: Rc<LocationTree>,
     zone_sentinel: Option<OwnedFederation>,
 }
 
 impl State {
-    pub fn new(decorated_locations: LocationTree, zone: OwnedFederation) -> Self {
+    pub fn new(decorated_locations: Rc<LocationTree>, zone: OwnedFederation) -> Self {
         State {
             decorated_locations,
             zone_sentinel: Some(zone),
@@ -25,7 +27,7 @@ impl State {
     }
 
     pub fn from_location(
-        decorated_locations: LocationTree,
+        decorated_locations: Rc<LocationTree>,
         dimensions: ClockIndex,
     ) -> Option<Self> {
         let mut fed = OwnedFederation::init(dimensions);
@@ -78,7 +80,7 @@ impl State {
     }
 
     pub fn extrapolate_max_bounds(&mut self, system: &dyn TransitionSystem) {
-        let bounds = system.get_local_max_bounds(&self.decorated_locations);
+        let bounds = system.get_local_max_bounds(self.decorated_locations.as_ref());
         self.update_zone(|zone| zone.extrapolate_max_bounds(&bounds))
     }
 
@@ -87,7 +89,7 @@ impl State {
         system: &dyn TransitionSystem,
         extra_bounds: &Bounds,
     ) {
-        let mut bounds = system.get_local_max_bounds(&self.decorated_locations);
+        let mut bounds = system.get_local_max_bounds(self.decorated_locations.as_ref());
         bounds.add_bounds(extra_bounds);
         self.update_zone(|zone| zone.extrapolate_max_bounds(&bounds))
     }

--- a/src/model_objects/statepair.rs
+++ b/src/model_objects/statepair.rs
@@ -72,19 +72,14 @@ impl StatePair {
     }
 
     pub fn extrapolate_max_bounds(
-        self,
+        &mut self,
         sys1: &TransitionSystemPtr,
         sys2: &TransitionSystemPtr,
-    ) -> Self {
+    ) {
         let mut bounds = sys1.get_local_max_bounds(self.locations1.as_ref());
         bounds.add_bounds(&sys2.get_local_max_bounds(self.locations2.as_ref()));
-        let zone = self.clone_zone().extrapolate_max_bounds(&bounds);
 
-        StatePair {
-            locations1: self.locations1,
-            locations2: self.locations2,
-            zone: Rc::new(zone),
-        }
+        self.zone = Rc::new(self.clone_zone().extrapolate_max_bounds(&bounds));
     }
 }
 

--- a/src/model_objects/statepair.rs
+++ b/src/model_objects/statepair.rs
@@ -8,16 +8,16 @@ use std::{
 
 #[derive(Clone, Debug)]
 pub struct StatePair {
-    pub locations1: LocationTree,
-    pub locations2: LocationTree,
+    pub locations1: Rc<LocationTree>,
+    pub locations2: Rc<LocationTree>,
     zone: Rc<OwnedFederation>,
 }
 
 impl StatePair {
     pub fn from_locations(
         dimensions: usize,
-        locations1: LocationTree,
-        locations2: LocationTree,
+        locations1: Rc<LocationTree>,
+        locations2: Rc<LocationTree>,
     ) -> StatePair {
         let mut zone = OwnedFederation::init(dimensions);
 
@@ -32,8 +32,8 @@ impl StatePair {
     }
 
     pub fn new(
-        locations1: LocationTree,
-        locations2: LocationTree,
+        locations1: Rc<LocationTree>,
+        locations2: Rc<LocationTree>,
         zone: Rc<OwnedFederation>,
     ) -> Self {
         StatePair {
@@ -43,25 +43,25 @@ impl StatePair {
         }
     }
 
-    pub fn get_locations1(&self) -> &LocationTree {
-        &self.locations1
+    pub fn get_locations1(&self) -> Rc<LocationTree> {
+        self.locations1.clone()
     }
 
-    pub fn get_locations2(&self) -> &LocationTree {
-        &self.locations2
+    pub fn get_locations2(&self) -> Rc<LocationTree> {
+        self.locations2.clone()
     }
 
     //Used to allow borrowing both states as mutable
-    pub fn get_mut_locations(
-        &mut self,
-        is_states1: bool,
-    ) -> (&mut LocationTree, &mut LocationTree) {
-        if is_states1 {
-            (&mut self.locations1, &mut self.locations2)
-        } else {
-            (&mut self.locations2, &mut self.locations1)
-        }
-    }
+    // pub fn get_mut_locations(
+    //     &mut self,
+    //     is_states1: bool,
+    // ) -> (&mut LocationTree, &mut LocationTree) {
+    //     if is_states1 {
+    //         (&mut self.locations1, &mut self.locations2)
+    //     } else {
+    //         (&mut self.locations2, &mut self.locations1)
+    //     }
+    // }
 
     pub fn get_locations(&self, is_states1: bool) -> (&LocationTree, &LocationTree) {
         if is_states1 {
@@ -88,8 +88,8 @@ impl StatePair {
         sys1: &TransitionSystemPtr,
         sys2: &TransitionSystemPtr,
     ) -> Self {
-        let mut bounds = sys1.get_local_max_bounds(&self.locations1);
-        bounds.add_bounds(&sys2.get_local_max_bounds(&self.locations2));
+        let mut bounds = sys1.get_local_max_bounds(self.locations1.as_ref());
+        bounds.add_bounds(&sys2.get_local_max_bounds(self.locations2.as_ref()));
         let zone = self.clone_zone().extrapolate_max_bounds(&bounds);
 
         StatePair {

--- a/src/model_objects/statepair.rs
+++ b/src/model_objects/statepair.rs
@@ -51,18 +51,6 @@ impl StatePair {
         self.locations2.clone()
     }
 
-    //Used to allow borrowing both states as mutable
-    // pub fn get_mut_locations(
-    //     &mut self,
-    //     is_states1: bool,
-    // ) -> (&mut LocationTree, &mut LocationTree) {
-    //     if is_states1 {
-    //         (&mut self.locations1, &mut self.locations2)
-    //     } else {
-    //         (&mut self.locations2, &mut self.locations1)
-    //     }
-    // }
-
     pub fn get_locations(&self, is_states1: bool) -> (&LocationTree, &LocationTree) {
         if is_states1 {
             (&self.locations1, &self.locations2)

--- a/src/model_objects/statepair.rs
+++ b/src/model_objects/statepair.rs
@@ -1,14 +1,16 @@
 use edbm::zones::OwnedFederation;
 
 use crate::transition_systems::{LocationTree, TransitionSystemPtr};
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    rc::Rc,
+};
 
 #[derive(Clone, Debug)]
 pub struct StatePair {
     pub locations1: LocationTree,
     pub locations2: LocationTree,
-    /// The sentinel (Option) allows us to take ownership of the internal fed from a mutable reference
-    zone_sentinel: Option<OwnedFederation>,
+    zone: Rc<OwnedFederation>,
 }
 
 impl StatePair {
@@ -17,12 +19,27 @@ impl StatePair {
         locations1: LocationTree,
         locations2: LocationTree,
     ) -> StatePair {
-        let zone = OwnedFederation::init(dimensions);
+        let mut zone = OwnedFederation::init(dimensions);
+
+        zone = locations1.apply_invariants(zone);
+        zone = locations2.apply_invariants(zone);
 
         StatePair {
             locations1,
             locations2,
-            zone_sentinel: Some(zone),
+            zone: Rc::new(zone),
+        }
+    }
+
+    pub fn new(
+        locations1: LocationTree,
+        locations2: LocationTree,
+        zone: Rc<OwnedFederation>,
+    ) -> Self {
+        StatePair {
+            locations1,
+            locations2,
+            zone,
         }
     }
 
@@ -35,7 +52,10 @@ impl StatePair {
     }
 
     //Used to allow borrowing both states as mutable
-    pub fn get_mut_states(&mut self, is_states1: bool) -> (&mut LocationTree, &mut LocationTree) {
+    pub fn get_mut_locations(
+        &mut self,
+        is_states1: bool,
+    ) -> (&mut LocationTree, &mut LocationTree) {
         if is_states1 {
             (&mut self.locations1, &mut self.locations2)
         } else {
@@ -52,30 +72,31 @@ impl StatePair {
     }
 
     pub fn clone_zone(&self) -> OwnedFederation {
-        self.ref_zone().clone()
+        self.zone.as_ref().clone()
     }
 
     pub fn ref_zone(&self) -> &OwnedFederation {
-        self.zone_sentinel.as_ref().unwrap()
+        self.zone.as_ref()
     }
 
-    pub fn take_zone(&mut self) -> OwnedFederation {
-        self.zone_sentinel.take().unwrap()
-    }
-
-    pub fn set_zone(&mut self, zone: OwnedFederation) {
-        self.zone_sentinel = Some(zone);
+    pub fn get_zone(&self) -> Rc<OwnedFederation> {
+        Rc::clone(&self.zone)
     }
 
     pub fn extrapolate_max_bounds(
-        &mut self,
+        self,
         sys1: &TransitionSystemPtr,
         sys2: &TransitionSystemPtr,
-    ) {
+    ) -> Self {
         let mut bounds = sys1.get_local_max_bounds(&self.locations1);
         bounds.add_bounds(&sys2.get_local_max_bounds(&self.locations2));
-        let zone = self.take_zone().extrapolate_max_bounds(&bounds);
-        self.set_zone(zone);
+        let zone = self.clone_zone().extrapolate_max_bounds(&bounds);
+
+        StatePair {
+            locations1: self.locations1,
+            locations2: self.locations2,
+            zone: Rc::new(zone),
+        }
     }
 }
 

--- a/src/model_objects/statepair_list.rs
+++ b/src/model_objects/statepair_list.rs
@@ -26,7 +26,7 @@ pub trait PassedStateListExt {
 impl PassedStateListExt for PassedStateListVec {
     fn put(&mut self, pair: StatePair) {
         let fed = pair.get_zone();
-        let (loc1, loc2) = (pair.locations1.id, pair.locations2.id);
+        let (loc1, loc2) = (pair.locations1.id.clone(), pair.locations2.id.clone());
         let key = (loc1, loc2);
         if let Some(vec) = self.get_mut(&key) {
             vec.push(fed);
@@ -60,7 +60,7 @@ impl PassedStateListExt for DepthFirstWaitingStateList {
     fn put(&mut self, pair: StatePair) {
         self.queue.push_front(pair.clone());
         let fed = pair.get_zone();
-        let (loc1, loc2) = (pair.locations1.id, pair.locations2.id);
+        let (loc1, loc2) = (pair.locations1.id.clone(), pair.locations2.id.clone());
         let key = (loc1, loc2);
         if let Some(vec) = self.map.get_mut(&key) {
             vec.push_front(fed);
@@ -120,7 +120,7 @@ impl DepthFirstWaitingStateList {
 impl PassedStateListExt for PassedStateListFed {
     fn put(&mut self, pair: StatePair) {
         let mut fed = pair.clone_zone();
-        let (loc1, loc2) = (pair.locations1.id, pair.locations2.id);
+        let (loc1, loc2) = (pair.locations1.id.clone(), pair.locations2.id.clone());
         let key = (loc1, loc2);
 
         if let Some(f) = self.get(&key) {

--- a/src/model_objects/transition.rs
+++ b/src/model_objects/transition.rs
@@ -53,19 +53,17 @@ impl Transition {
     }
 
     pub fn use_transition(&self, state: &mut State) -> bool {
-        let mut zone = state.take_zone();
+        let mut zone = state.clone_zone();
         zone = self.apply_guards(zone);
         if !zone.is_empty() {
             zone = self.apply_updates(zone).up();
             state.decorated_locations = Rc::clone(&self.target_locations);
             zone = state.decorated_locations.apply_invariants(zone);
-            if !zone.is_empty() {
-                state.set_zone(zone);
-                return true;
-            }
         }
+        let empty = !zone.is_empty();
         state.set_zone(zone);
-        false
+
+        empty
     }
 
     /// Returns the resulting [`State`] when using a transition in the given [`State`]

--- a/src/system/extract_state.rs
+++ b/src/system/extract_state.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use edbm::zones::OwnedFederation;
 use itertools::Itertools;
 
@@ -110,29 +112,29 @@ fn construct_location_tree(
     locations: &Vec<ComponentVariable>,
     machine: &SystemRecipe,
     system: &TransitionSystemPtr,
-) -> Result<LocationTree, String> {
+) -> Result<Rc<LocationTree>, String> {
     match machine {
         SystemRecipe::Composition(left, right) => {
             let (left_system, right_system) = system.get_children();
             Ok(LocationTree::compose(
-                &construct_location_tree(locations, left, left_system)?,
-                &construct_location_tree(locations, right, right_system)?,
+                construct_location_tree(locations, left, left_system)?,
+                construct_location_tree(locations, right, right_system)?,
                 CompositionType::Composition,
             ))
         }
         SystemRecipe::Conjunction(left, right) => {
             let (left_system, right_system) = system.get_children();
             Ok(LocationTree::compose(
-                &construct_location_tree(locations, left, left_system)?,
-                &construct_location_tree(locations, right, right_system)?,
+                construct_location_tree(locations, left, left_system)?,
+                construct_location_tree(locations, right, right_system)?,
                 CompositionType::Conjunction,
             ))
         }
         SystemRecipe::Quotient(left, right, ..) => {
             let (left_system, right_system) = system.get_children();
             Ok(LocationTree::merge_as_quotient(
-                &construct_location_tree(locations, left, left_system)?,
-                &construct_location_tree(locations, right, right_system)?,
+                construct_location_tree(locations, left, left_system)?,
+                construct_location_tree(locations, right, right_system)?,
             ))
         }
         SystemRecipe::Component(component) => {

--- a/src/system/local_consistency.rs
+++ b/src/system/local_consistency.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use edbm::zones::OwnedFederation;
 use log::warn;
 
@@ -44,7 +46,7 @@ fn is_deterministic_helper(
 
     for action in system.get_actions() {
         let mut location_fed = OwnedFederation::empty(system.get_dim());
-        for transition in &system.next_transitions(&state.decorated_locations, &action) {
+        for transition in &system.next_transitions(Rc::clone(&state.decorated_locations), &action) {
             let mut new_state = state.clone();
             if transition.use_transition(&mut new_state) {
                 let mut allowed_fed = transition.get_allowed_federation();
@@ -95,7 +97,7 @@ pub fn consistency_least_helper(
     passed_list.push(state.clone());
 
     for input in system.get_input_actions() {
-        for transition in &system.next_inputs(&state.decorated_locations, &input) {
+        for transition in &system.next_inputs(Rc::clone(&state.decorated_locations), &input) {
             let mut new_state = state.clone();
             if transition.use_transition(&mut new_state) {
                 new_state.extrapolate_max_bounds(system);
@@ -110,7 +112,7 @@ pub fn consistency_least_helper(
     }
 
     for output in system.get_output_actions() {
-        for transition in system.next_outputs(&state.decorated_locations, &output) {
+        for transition in system.next_outputs(Rc::clone(&state.decorated_locations), &output) {
             let mut new_state = state.clone();
             if transition.use_transition(&mut new_state) {
                 new_state.extrapolate_max_bounds(system);
@@ -135,7 +137,7 @@ fn consistency_fully_helper(
     passed_list.push(state.clone());
 
     for input in system.get_input_actions() {
-        for transition in system.next_inputs(&state.decorated_locations, &input) {
+        for transition in system.next_inputs(Rc::clone(&state.decorated_locations), &input) {
             let mut new_state = state.clone();
             if transition.use_transition(&mut new_state) {
                 new_state.extrapolate_max_bounds(system);
@@ -149,7 +151,7 @@ fn consistency_fully_helper(
 
     let mut output_existed = false;
     for output in system.get_output_actions() {
-        for transition in system.next_outputs(&state.decorated_locations, &output) {
+        for transition in system.next_outputs(Rc::clone(&state.decorated_locations), &output) {
             let mut new_state = state.clone();
             if transition.use_transition(&mut new_state) {
                 new_state.extrapolate_max_bounds(system);

--- a/src/system/local_consistency.rs
+++ b/src/system/local_consistency.rs
@@ -107,7 +107,7 @@ pub fn consistency_least_helper(
         }
     }
 
-    if state.zone_ref().can_delay_indefinitely() {
+    if state.ref_zone().can_delay_indefinitely() {
         return Ok(());
     }
 
@@ -169,7 +169,7 @@ fn consistency_fully_helper(
         Ok(())
     } else {
         let last_state = passed_list.last().unwrap();
-        match last_state.zone_ref().can_delay_indefinitely() {
+        match last_state.ref_zone().can_delay_indefinitely() {
             false => ConsistencyFailure::inconsistent_from(system, &state),
             true => Ok(()),
         }

--- a/src/system/reachability.rs
+++ b/src/system/reachability.rs
@@ -134,9 +134,10 @@ fn reachability_search(
         }
 
         for action in &actions {
-            for transition in
-                &system.next_transitions(&sub_path.destination_state.decorated_locations, action)
-            {
+            for transition in &system.next_transitions(
+                Rc::clone(&sub_path.destination_state.decorated_locations),
+                action,
+            ) {
                 take_transition(
                     &sub_path,
                     transition,
@@ -156,7 +157,7 @@ fn reachability_search(
 fn reached_end_state(cur_state: &State, end_state: &State) -> bool {
     cur_state
         .decorated_locations
-        .compare_partial_locations(&end_state.decorated_locations)
+        .compare_partial_locations(Rc::clone(&end_state.decorated_locations))
         && cur_state.zone_ref().has_intersection(end_state.zone_ref())
 }
 

--- a/src/system/reachability.rs
+++ b/src/system/reachability.rs
@@ -25,13 +25,13 @@ struct SubPath {
 
 fn is_trivially_unreachable(start_state: &State, end_state: &State) -> bool {
     // If any of the zones are empty
-    if start_state.zone_ref().is_empty() || end_state.zone_ref().is_empty() {
+    if start_state.ref_zone().is_empty() || end_state.ref_zone().is_empty() {
         return true;
     }
 
     // If the end location has invariants and these do not have an intersection (overlap) with the zone of the end state of the query
     if let Some(invariants) = end_state.decorated_locations.get_invariants() {
-        if !end_state.zone_ref().has_intersection(invariants) {
+        if !end_state.ref_zone().has_intersection(invariants) {
             return true;
         }
     }
@@ -115,7 +115,7 @@ fn reachability_search(
     // Push start state to visited state
     visited_states.insert(
         start_state.decorated_locations.id.clone(),
-        vec![start_state.zone_ref().clone()],
+        vec![start_state.ref_zone().clone()],
     );
 
     // Push initial state to frontier
@@ -125,7 +125,7 @@ fn reachability_search(
         transition: None,
     }));
 
-    let target_bounds = end_state.zone_ref().get_bounds();
+    let target_bounds = end_state.ref_zone().get_bounds();
 
     // Take the first state from the frontier and explore it
     while let Some(sub_path) = frontier_states.pop_front() {
@@ -158,7 +158,7 @@ fn reached_end_state(cur_state: &State, end_state: &State) -> bool {
     cur_state
         .decorated_locations
         .compare_partial_locations(Rc::clone(&end_state.decorated_locations))
-        && cur_state.zone_ref().has_intersection(end_state.zone_ref())
+        && cur_state.ref_zone().has_intersection(end_state.ref_zone())
 }
 
 fn take_transition(
@@ -178,14 +178,14 @@ fn take_transition(
         let new_location_id = &new_state.decorated_locations.id;
         let existing_zones = visited_states.entry(new_location_id.clone()).or_default();
         // If this location has not already been reached (explored) with a larger zone
-        if !zone_subset_of_existing_zones(new_state.zone_ref(), existing_zones) {
+        if !zone_subset_of_existing_zones(new_state.ref_zone(), existing_zones) {
             // Remove the smaller zones for this location in visited_states
-            remove_existing_subsets_of_zone(new_state.zone_ref(), existing_zones);
+            remove_existing_subsets_of_zone(new_state.ref_zone(), existing_zones);
             // Add the new zone to the list of zones for this location in visited_states
             visited_states
                 .get_mut(new_location_id)
                 .unwrap()
-                .push(new_state.zone_ref().clone());
+                .push(new_state.ref_zone().clone());
             // Add the new state to the frontier
             frontier_states.push_back(Rc::new(SubPath {
                 previous_sub_path: Some(Rc::clone(sub_path)),

--- a/src/system/refine.rs
+++ b/src/system/refine.rs
@@ -148,7 +148,7 @@ pub fn check_refinement(sys1: TransitionSystemPtr, sys2: TransitionSystemPtr) ->
     if initial_pair.ref_zone().is_empty() {
         return RefinementFailure::empty_initial(sys1.as_ref(), sys2.as_ref());
     }
-    initial_pair = initial_pair.extrapolate_max_bounds(context.sys1, context.sys2);
+    initial_pair.extrapolate_max_bounds(context.sys1, context.sys2);
 
     debug!("Initial {}", initial_pair);
     context.waiting_list.put(initial_pair);
@@ -361,8 +361,8 @@ fn build_state_pair(
 
     //Update locations in states
     let (locations1, locations2) = (
-        transition1.target_locations.clone(),
-        transition2.target_locations.clone(),
+        Rc::clone(&transition1.target_locations),
+        Rc::clone(&transition2.target_locations),
     );
 
     // Apply invariants on the left side of relation
@@ -394,7 +394,7 @@ fn build_state_pair(
     }
 
     let mut new_sp = StatePair::new(left_loc, right_loc, Rc::new(new_sp_zone));
-    new_sp = new_sp.extrapolate_max_bounds(context.sys1, context.sys2);
+    new_sp.extrapolate_max_bounds(context.sys1, context.sys2);
 
     if !context.passed_list.has(&new_sp) && !context.waiting_list.has(&new_sp) {
         debug!("New state {}", new_sp);

--- a/src/system/refine.rs
+++ b/src/system/refine.rs
@@ -141,8 +141,8 @@ pub fn check_refinement(sys1: TransitionSystemPtr, sys2: TransitionSystemPtr) ->
 
     let mut initial_pair = StatePair::from_locations(
         dimensions,
-        initial_locations_1.clone(),
-        initial_locations_2.clone(),
+        Rc::clone(&initial_locations_1),
+        Rc::clone(&initial_locations_2),
     );
 
     if initial_pair.ref_zone().is_empty() {

--- a/src/system/refine.rs
+++ b/src/system/refine.rs
@@ -5,8 +5,9 @@ use crate::model_objects::{
     PassedStateList, PassedStateListExt, StatePair, Transition, WaitingStateList,
 };
 use crate::system::query_failures::RefinementFailure;
-use crate::transition_systems::{LocationTree, TransitionSystemPtr};
+use crate::transition_systems::TransitionSystemPtr;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 use super::query_failures::{ActionFailure, RefinementPrecondition, RefinementResult};
 
@@ -144,10 +145,10 @@ pub fn check_refinement(sys1: TransitionSystemPtr, sys2: TransitionSystemPtr) ->
         initial_locations_2.clone(),
     );
 
-    if !prepare_init_state(&mut initial_pair, initial_locations_1, initial_locations_2) {
+    if initial_pair.ref_zone().is_empty() {
         return RefinementFailure::empty_initial(sys1.as_ref(), sys2.as_ref());
     }
-    initial_pair.extrapolate_max_bounds(context.sys1, context.sys2);
+    initial_pair = initial_pair.extrapolate_max_bounds(context.sys1, context.sys2);
 
     debug!("Initial {}", initial_pair);
     context.waiting_list.put(initial_pair);
@@ -336,12 +337,10 @@ fn build_state_pair(
     context: &mut RefinementContext,
     is_state1: bool,
 ) -> BuildResult {
-    //Creates new state pair
-    let mut new_sp: StatePair = curr_pair.clone();
     //Creates DBM for that state pair
-    let mut new_sp_zone = new_sp.take_zone();
+    let mut new_sp_zone = curr_pair.clone_zone();
+
     //Apply guards on both sides
-    let (locations1, locations2) = new_sp.get_mut_states(is_state1);
 
     //Applies the left side guards and checks if zone is valid
     new_sp_zone = transition1.apply_guards(new_sp_zone);
@@ -361,16 +360,15 @@ fn build_state_pair(
     new_sp_zone = new_sp_zone.up();
 
     //Update locations in states
-
-    transition1.move_locations(locations1);
-    transition2.move_locations(locations2);
+    let (locations1, locations2) = (
+        transition1.target_locations.clone(),
+        transition2.target_locations.clone(),
+    );
 
     // Apply invariants on the left side of relation
     let (left_loc, right_loc) = if is_state1 {
-        //(locations2, locations1)
         (locations1, locations2)
     } else {
-        //(locations1, locations2)
         (locations2, locations1)
     };
 
@@ -395,9 +393,8 @@ fn build_state_pair(
         return BuildResult::Failure;
     }
 
-    new_sp.set_zone(new_sp_zone);
-
-    new_sp.extrapolate_max_bounds(context.sys1, context.sys2);
+    let mut new_sp = StatePair::new(left_loc, right_loc, Rc::new(new_sp_zone));
+    new_sp = new_sp.extrapolate_max_bounds(context.sys1, context.sys2);
 
     if !context.passed_list.has(&new_sp) && !context.waiting_list.has(&new_sp) {
         debug!("New state {}", new_sp);
@@ -406,20 +403,6 @@ fn build_state_pair(
     }
 
     BuildResult::Success
-}
-
-fn prepare_init_state(
-    initial_pair: &mut StatePair,
-    initial_locations_1: LocationTree,
-    initial_locations_2: LocationTree,
-) -> bool {
-    let mut sp_zone = initial_pair.take_zone();
-    sp_zone = initial_locations_1.apply_invariants(sp_zone);
-    sp_zone = initial_locations_2.apply_invariants(sp_zone);
-
-    initial_pair.set_zone(sp_zone);
-
-    !initial_pair.ref_zone().is_empty()
 }
 
 fn check_preconditions(

--- a/src/system/save_component.rs
+++ b/src/system/save_component.rs
@@ -2,6 +2,7 @@ use crate::model_objects::expressions::BoolExpression;
 use crate::model_objects::{Component, Declarations, Location, LocationType, SyncType};
 use crate::transition_systems::{LocationTree, TransitionSystemPtr};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 pub enum PruningStrategy {
     Reachable,
@@ -16,7 +17,7 @@ pub fn combine_components(
     system: &TransitionSystemPtr,
     reachability: PruningStrategy,
 ) -> Component {
-    let mut location_trees = vec![];
+    let mut location_trees: Vec<Rc<LocationTree>> = vec![];
     let mut edges = vec![];
     let clocks = get_clock_map(system);
     match reachability {
@@ -28,7 +29,7 @@ pub fn combine_components(
         }
     };
 
-    let locations = get_locations_from_trees(&location_trees, &clocks);
+    let locations = get_locations_from_trees(location_trees.as_slice(), &clocks);
 
     Component {
         name: "".to_string(),
@@ -43,7 +44,7 @@ pub fn combine_components(
 }
 
 pub fn get_locations_from_trees(
-    location_trees: &[LocationTree],
+    location_trees: &[Rc<LocationTree>],
     clock_map: &HashMap<String, ClockIndex>,
 ) -> Vec<Location> {
     location_trees
@@ -92,20 +93,20 @@ pub fn get_clock_map(sysrep: &TransitionSystemPtr) -> HashMap<String, ClockIndex
 
 fn collect_all_edges_and_locations(
     representation: &TransitionSystemPtr,
-    locations: &mut Vec<LocationTree>,
+    locations: &mut Vec<Rc<LocationTree>>,
     edges: &mut Vec<Edge>,
     clock_map: &HashMap<String, ClockIndex>,
 ) {
     let l = representation.get_all_locations();
     locations.extend(l);
     for location in locations {
-        collect_edges_from_location(location, representation, edges, clock_map);
+        collect_edges_from_location(Rc::clone(location), representation, edges, clock_map);
     }
 }
 
 fn collect_reachable_edges_and_locations(
     representation: &TransitionSystemPtr,
-    locations: &mut Vec<LocationTree>,
+    locations: &mut Vec<Rc<LocationTree>>,
     edges: &mut Vec<Edge>,
     clock_map: &HashMap<String, ClockIndex>,
 ) {
@@ -118,17 +119,17 @@ fn collect_reachable_edges_and_locations(
 
     locations.push(l.clone());
 
-    collect_reachable_locations(&l, representation, locations);
+    collect_reachable_locations(l, representation, locations);
 
     for loc in locations {
-        collect_edges_from_location(loc, representation, edges, clock_map);
+        collect_edges_from_location(Rc::clone(loc), representation, edges, clock_map);
     }
 }
 
 fn collect_reachable_locations(
-    location: &LocationTree,
+    location: Rc<LocationTree>,
     representation: &TransitionSystemPtr,
-    locations: &mut Vec<LocationTree>,
+    locations: &mut Vec<Rc<LocationTree>>,
 ) {
     for input in [true, false].iter() {
         for sync in if *input {
@@ -136,15 +137,14 @@ fn collect_reachable_locations(
         } else {
             representation.get_output_actions()
         } {
-            let transitions = representation.next_transitions(location, &sync);
+            let transitions = representation.next_transitions(Rc::clone(&location), &sync);
 
             for transition in transitions {
-                let mut target_location = location.clone();
-                transition.move_locations(&mut target_location);
+                let target_location = transition.target_locations;
 
                 if !locations.contains(&target_location) {
-                    locations.push(target_location.clone());
-                    collect_reachable_locations(&target_location, representation, locations);
+                    locations.push(Rc::clone(&target_location));
+                    collect_reachable_locations(target_location, representation, locations);
                 }
             }
         }
@@ -152,17 +152,29 @@ fn collect_reachable_locations(
 }
 
 fn collect_edges_from_location(
-    location: &LocationTree,
+    location: Rc<LocationTree>,
     representation: &TransitionSystemPtr,
     edges: &mut Vec<Edge>,
     clock_map: &HashMap<String, ClockIndex>,
 ) {
-    collect_specific_edges_from_location(location, representation, edges, true, clock_map);
-    collect_specific_edges_from_location(location, representation, edges, false, clock_map);
+    collect_specific_edges_from_location(
+        Rc::clone(&location),
+        representation,
+        edges,
+        true,
+        clock_map,
+    );
+    collect_specific_edges_from_location(
+        Rc::clone(&location),
+        representation,
+        edges,
+        false,
+        clock_map,
+    );
 }
 
 fn collect_specific_edges_from_location(
-    location: &LocationTree,
+    location: Rc<LocationTree>,
     representation: &TransitionSystemPtr,
     edges: &mut Vec<Edge>,
     input: bool,
@@ -173,10 +185,9 @@ fn collect_specific_edges_from_location(
     } else {
         representation.get_output_actions()
     } {
-        let transitions = representation.next_transitions(location, &sync);
+        let transitions = representation.next_transitions(Rc::clone(&location), &sync);
         for transition in transitions {
-            let mut target_location = location.clone();
-            transition.move_locations(&mut target_location);
+            let target_location_id = transition.target_locations.id.to_string();
 
             let guard = transition.get_renamed_guard_expression(clock_map);
             if let Some(BoolExpression::Bool(false)) = guard {
@@ -186,7 +197,7 @@ fn collect_specific_edges_from_location(
             let edge = Edge {
                 id: transition.id.to_string(),
                 source_location: location.id.to_string(),
-                target_location: target_location.id.to_string(),
+                target_location: target_location_id,
                 sync_type: if input {
                     SyncType::Input
                 } else {

--- a/src/system/save_component.rs
+++ b/src/system/save_component.rs
@@ -17,7 +17,7 @@ pub fn combine_components(
     system: &TransitionSystemPtr,
     reachability: PruningStrategy,
 ) -> Component {
-    let mut location_trees: Vec<Rc<LocationTree>> = vec![];
+    let mut location_trees = vec![];
     let mut edges = vec![];
     let clocks = get_clock_map(system);
     match reachability {

--- a/src/system/specifics.rs
+++ b/src/system/specifics.rs
@@ -291,7 +291,7 @@ impl SpecificState {
         let locations = state_specific_location(state, sys);
         let clock_map = specific_clock_comp_map(sys);
 
-        let constraints = state.zone_ref().minimal_constraints();
+        let constraints = state.ref_zone().minimal_constraints();
         let constraints = SpecificDisjunction::from_disjunction(constraints, &clock_map);
         Self {
             locations,

--- a/src/tests/edge_ids/transition_id_tests.rs
+++ b/src/tests/edge_ids/transition_id_tests.rs
@@ -2,6 +2,7 @@
 mod reachability_transition_id_test {
     use std::collections::HashSet;
     use std::iter::FromIterator;
+    use std::rc::Rc;
 
     use crate::model_objects::expressions::SystemExpression;
     use crate::tests::reachability::helper_functions::reachability_test_helper_functions;
@@ -81,7 +82,7 @@ mod reachability_transition_id_test {
         );
         for loc in system.get_all_locations() {
             for ac in system.get_actions() {
-                for tran in system.next_transitions(&loc, &ac) {
+                for tran in system.next_transitions(Rc::clone(&loc), &ac) {
                     if expected_ids.contains(&tran.id) {
                         expected_ids.remove(&tran.id);
                     } else {

--- a/src/tests/reachability/partial_state.rs
+++ b/src/tests/reachability/partial_state.rs
@@ -33,7 +33,7 @@ mod reachability_partial_states_test {
                 "L5//_ == L5//L1")]
     #[test_case(LocationTree::compose(build_location_tree_helper("L5", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Conjunction),
                 LocationTree::compose(LocationTree::build_any_location_tree(), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L5_ == _L1")]
+                "L5&&_ == _&&L1")]
     #[test_case(LocationTree::compose(build_location_tree_helper("L7", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Composition),
                 LocationTree::compose(build_location_tree_helper("L7", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
                 "L7||_ == L7||L1")]
@@ -58,31 +58,31 @@ mod reachability_partial_states_test {
                 "L2//L6 != L2||L1")]
     #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L7", LocationType::Normal), build_location_tree_helper("L6", LocationType::Normal)),
                 LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L7//L6 != L2L1")]
+                "L7//L6 != L2&&L1")]
     #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L8", LocationType::Normal), LocationTree::build_any_location_tree()),
                 LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L8//_ != L2L1")]
+                "L8//_ != L2&&L1")]
     #[test_case(LocationTree::build_any_location_tree(),
                 LocationTree::compose(build_location_tree_helper("L6", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "_ != L6L1")]
+                "_ != L6&&L1")]
     #[test_case(LocationTree::build_any_location_tree(),
                 LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Conjunction);
-                "anylocation _ != __")]
+                "anylocation _ != _&&_")]
     #[test_case(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L4", LocationType::Normal), CompositionType::Conjunction),
                 LocationTree::merge_as_quotient(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L4", LocationType::Normal));
-                "L2L4 != L2\\L4")]
+                "L2&&L4 != L2\\L4")]
     #[test_case(LocationTree::compose(LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
                 LocationTree::compose(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition);
-                "_||_L2 == L2||L1||L2")]
+                "_||_&&L2 == L2||L1||L2")]
     #[test_case(LocationTree::compose(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
                 LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Conjunction);
-                "L2||_L2 == __")]
+                "L2||_&&L2 == _&&_")]
     #[test_case(build_location_tree_helper("L7", LocationType::Normal),
                 build_location_tree_helper("L5", LocationType::Normal);
                 "L7 != L5")]
     #[test_case(LocationTree::merge_as_quotient(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree()),
                 LocationTree::compose(build_location_tree_helper("L6", LocationType::Normal), build_location_tree_helper("L25", LocationType::Normal), CompositionType::Conjunction);
-                "_//_ != L6L25")]
+                "_//_ != L6&&L25")]
     #[test_case(build_location_tree_helper("_L1", LocationType::Normal),
                 build_location_tree_helper("L1", LocationType::Normal);
                 "_L1 != L1")]

--- a/src/tests/reachability/partial_state.rs
+++ b/src/tests/reachability/partial_state.rs
@@ -1,11 +1,13 @@
 #[cfg(test)]
 mod reachability_partial_states_test {
+    use std::rc::Rc;
+
     use crate::model_objects::{Declarations, Location, LocationType};
     use crate::transition_systems::CompositionType;
     use crate::transition_systems::LocationTree;
     use test_case::test_case;
 
-    fn build_location_tree_helper(id: &str, location_type: LocationType) -> LocationTree {
+    fn build_location_tree_helper(id: &str, location_type: LocationType) -> Rc<LocationTree> {
         LocationTree::simple(
             &Location {
                 id: id.to_string(),
@@ -26,68 +28,68 @@ mod reachability_partial_states_test {
     #[test_case(build_location_tree_helper("L5", LocationType::Normal),
                 build_location_tree_helper("L5", LocationType::Normal);
                 "L5 == L5")]
-    #[test_case(LocationTree::merge_as_quotient(&build_location_tree_helper("L5", LocationType::Normal), &LocationTree::build_any_location_tree()),
-                LocationTree::merge_as_quotient(&build_location_tree_helper("L5", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal));
+    #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L5", LocationType::Normal), LocationTree::build_any_location_tree()),
+                LocationTree::merge_as_quotient(build_location_tree_helper("L5", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal));
                 "L5//_ == L5//L1")]
-    #[test_case(LocationTree::compose(&build_location_tree_helper("L5", LocationType::Normal), &LocationTree::build_any_location_tree(), CompositionType::Conjunction),
-                LocationTree::compose(&LocationTree::build_any_location_tree(), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L5&&_ == _&&L1")]
-    #[test_case(LocationTree::compose(&build_location_tree_helper("L7", LocationType::Normal), &LocationTree::build_any_location_tree(), CompositionType::Composition),
-                LocationTree::compose(&build_location_tree_helper("L7", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
+    #[test_case(LocationTree::compose(build_location_tree_helper("L5", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Conjunction),
+                LocationTree::compose(LocationTree::build_any_location_tree(), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
+                "L5_ == _L1")]
+    #[test_case(LocationTree::compose(build_location_tree_helper("L7", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Composition),
+                LocationTree::compose(build_location_tree_helper("L7", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
                 "L7||_ == L7||L1")]
-    #[test_case(LocationTree::compose(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree(), CompositionType::Composition),
-                LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
+    #[test_case(LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Composition),
+                LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
                 "_||_ == L2||L1")]
-    #[test_case(LocationTree::compose(&LocationTree::compose(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree(), CompositionType::Composition),&build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition),
-                LocationTree::compose(&LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition),&build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition);
+    #[test_case(LocationTree::compose(LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition),
+                LocationTree::compose(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition);
                 "_||_||L2 == L2||L1||L2")]
     #[test_case(build_location_tree_helper("L_35", LocationType::Normal),
                 build_location_tree_helper("L_35", LocationType::Normal);
                 "L_35 == L_35")]
-    fn checks_cmp_locations_returns_true(loc1: LocationTree, loc2: LocationTree) {
-        assert!(loc1.compare_partial_locations(&loc2));
+    fn checks_cmp_locations_returns_true(loc1: Rc<LocationTree>, loc2: Rc<LocationTree>) {
+        assert!(loc1.compare_partial_locations(loc2));
     }
 
-    #[test_case(LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L5", LocationType::Normal), CompositionType::Composition),
-                LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
+    #[test_case(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L5", LocationType::Normal), CompositionType::Composition),
+                LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
                 "L2||L5 != L2||L1")]
-    #[test_case(LocationTree::merge_as_quotient(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L6", LocationType::Normal)),
-                LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
+    #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L6", LocationType::Normal)),
+                LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition);
                 "L2//L6 != L2||L1")]
-    #[test_case(LocationTree::merge_as_quotient(&build_location_tree_helper("L7", LocationType::Normal), &build_location_tree_helper("L6", LocationType::Normal)),
-                LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L7//L6 != L2&&L1")]
-    #[test_case(LocationTree::merge_as_quotient(&build_location_tree_helper("L8", LocationType::Normal), &LocationTree::build_any_location_tree()),
-                LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "L8//_ != L2&&L1")]
+    #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L7", LocationType::Normal), build_location_tree_helper("L6", LocationType::Normal)),
+                LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
+                "L7//L6 != L2L1")]
+    #[test_case(LocationTree::merge_as_quotient(build_location_tree_helper("L8", LocationType::Normal), LocationTree::build_any_location_tree()),
+                LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
+                "L8//_ != L2L1")]
     #[test_case(LocationTree::build_any_location_tree(),
-                LocationTree::compose(&build_location_tree_helper("L6", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
-                "_ != L6&&L1")]
+                LocationTree::compose(build_location_tree_helper("L6", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Conjunction);
+                "_ != L6L1")]
     #[test_case(LocationTree::build_any_location_tree(),
-                LocationTree::compose(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree(), CompositionType::Conjunction);
-                "anylocation _ != _&&_")]
-    #[test_case(LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L4", LocationType::Normal), CompositionType::Conjunction),
-                LocationTree::merge_as_quotient(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L4", LocationType::Normal));
-                "L2&&L4 != L2\\L4")]
-    #[test_case(LocationTree::compose(&LocationTree::compose(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree(), CompositionType::Composition),&build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
-                LocationTree::compose(&LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition),&build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition);
-                "_||_&&L2 == L2||L1||L2")]
-    #[test_case(LocationTree::compose(&LocationTree::compose(&build_location_tree_helper("L2", LocationType::Normal), &LocationTree::build_any_location_tree(), CompositionType::Composition),&build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
-                LocationTree::compose(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree(), CompositionType::Conjunction);
-                "L2||_&&L2 == _&&_")]
+                LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Conjunction);
+                "anylocation _ != __")]
+    #[test_case(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L4", LocationType::Normal), CompositionType::Conjunction),
+                LocationTree::merge_as_quotient(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L4", LocationType::Normal));
+                "L2L4 != L2\\L4")]
+    #[test_case(LocationTree::compose(LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
+                LocationTree::compose(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), build_location_tree_helper("L1", LocationType::Normal), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Composition);
+                "_||_L2 == L2||L1||L2")]
+    #[test_case(LocationTree::compose(LocationTree::compose(build_location_tree_helper("L2", LocationType::Normal), LocationTree::build_any_location_tree(), CompositionType::Composition),build_location_tree_helper("L2", LocationType::Normal), CompositionType::Conjunction),
+                LocationTree::compose(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree(), CompositionType::Conjunction);
+                "L2||_L2 == __")]
     #[test_case(build_location_tree_helper("L7", LocationType::Normal),
                 build_location_tree_helper("L5", LocationType::Normal);
                 "L7 != L5")]
-    #[test_case(LocationTree::merge_as_quotient(&LocationTree::build_any_location_tree(), &LocationTree::build_any_location_tree()),
-                LocationTree::compose(&build_location_tree_helper("L6", LocationType::Normal), &build_location_tree_helper("L25", LocationType::Normal), CompositionType::Conjunction);
-                "_//_ != L6&&L25")]
+    #[test_case(LocationTree::merge_as_quotient(LocationTree::build_any_location_tree(), LocationTree::build_any_location_tree()),
+                LocationTree::compose(build_location_tree_helper("L6", LocationType::Normal), build_location_tree_helper("L25", LocationType::Normal), CompositionType::Conjunction);
+                "_//_ != L6L25")]
     #[test_case(build_location_tree_helper("_L1", LocationType::Normal),
                 build_location_tree_helper("L1", LocationType::Normal);
                 "_L1 != L1")]
     #[test_case(build_location_tree_helper("__", LocationType::Normal),
                 build_location_tree_helper("L7", LocationType::Normal);
                 "__ != L7")]
-    fn checks_cmp_locations_returns_false(loc1: LocationTree, loc2: LocationTree) {
-        assert!(!loc1.compare_partial_locations(&loc2));
+    fn checks_cmp_locations_returns_false(loc1: Rc<LocationTree>, loc2: Rc<LocationTree>) {
+        assert!(!loc1.compare_partial_locations(loc2));
     }
 }

--- a/src/transition_systems/composition.rs
+++ b/src/transition_systems/composition.rs
@@ -4,6 +4,7 @@ use crate::model_objects::Transition;
 use crate::system::query_failures::{ActionFailure, SystemRecipeFailure};
 use crate::transition_systems::{LocationTree, TransitionSystem, TransitionSystemPtr};
 use std::collections::hash_set::HashSet;
+use std::rc::Rc;
 
 use super::common::ComposedTransitionSystem;
 use super::CompositionType;
@@ -75,7 +76,7 @@ impl Composition {
 }
 
 impl ComposedTransitionSystem for Composition {
-    fn next_transitions(&self, location: &LocationTree, action: &str) -> Vec<Transition> {
+    fn next_transitions(&self, location: Rc<LocationTree>, action: &str) -> Vec<Transition> {
         assert!(self.actions_contain(action));
 
         let loc_left = location.get_left();

--- a/src/transition_systems/conjunction.rs
+++ b/src/transition_systems/conjunction.rs
@@ -7,6 +7,7 @@ use crate::transition_systems::{
     CompositionType, LocationTree, TransitionSystem, TransitionSystemPtr,
 };
 use std::collections::hash_set::HashSet;
+use std::rc::Rc;
 
 use super::common::ComposedTransitionSystem;
 
@@ -73,7 +74,7 @@ impl Conjunction {
 }
 
 impl ComposedTransitionSystem for Conjunction {
-    fn next_transitions(&self, location: &LocationTree, action: &str) -> Vec<Transition> {
+    fn next_transitions(&self, location: Rc<LocationTree>, action: &str) -> Vec<Transition> {
         assert!(self.actions_contain(action));
 
         let loc_left = location.get_left();

--- a/src/transition_systems/location_tree.rs
+++ b/src/transition_systems/location_tree.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use edbm::{util::constraints::ClockIndex, zones::OwnedFederation};
 
 use crate::edge_eval::constraint_applier::apply_constraints_to_state;
@@ -19,8 +21,8 @@ pub struct LocationTree {
     /// The invariant for the `Location`
     pub invariant: Option<OwnedFederation>,
     loc_type: LocationType,
-    left: Option<Box<LocationTree>>,
-    right: Option<Box<LocationTree>>,
+    left: Option<Rc<LocationTree>>,
+    right: Option<Rc<LocationTree>>,
 }
 
 impl PartialEq for LocationTree {
@@ -30,29 +32,29 @@ impl PartialEq for LocationTree {
 }
 
 impl LocationTree {
-    pub fn universal() -> Self {
-        LocationTree {
+    pub fn universal() -> Rc<Self> {
+        Rc::new(LocationTree {
             id: LocationID::Special(crate::system::specifics::SpecialLocation::Universal),
             invariant: None,
             loc_type: LocationType::Universal,
             left: None,
             right: None,
-        }
+        })
     }
 
-    pub fn error(dim: ClockIndex, quotient_clock_index: ClockIndex) -> Self {
+    pub fn error(dim: ClockIndex, quotient_clock_index: ClockIndex) -> Rc<Self> {
         let inv = OwnedFederation::universe(dim).constrain_eq(quotient_clock_index, 0);
 
-        LocationTree {
+        Rc::new(LocationTree {
             id: LocationID::Special(crate::system::specifics::SpecialLocation::Error),
             invariant: Some(inv),
             loc_type: LocationType::Inconsistent,
             left: None,
             right: None,
-        }
+        })
     }
 
-    pub fn simple(location: &Location, decls: &Declarations, dim: ClockIndex) -> Self {
+    pub fn simple(location: &Location, decls: &Declarations, dim: ClockIndex) -> Rc<Self> {
         let invariant = if let Some(inv) = &location.invariant {
             let mut fed = OwnedFederation::universe(dim);
             fed = apply_constraints_to_state(inv, decls, fed).unwrap();
@@ -60,45 +62,45 @@ impl LocationTree {
         } else {
             None
         };
-        LocationTree {
+        Rc::new(LocationTree {
             id: LocationID::Simple(location.id.clone()),
             invariant,
             loc_type: location.location_type,
             left: None,
             right: None,
-        }
+        })
     }
     /// This method is used to a build partial [`LocationTree`].
     /// A partial [`LocationTree`] means it has a [`LocationID`] that is [`LocationID::AnyLocation`].
     /// A partial [`LocationTree`] has `None` in the field `invariant` since a partial [`LocationTree`]
     /// covers more than one location, and therefore there is no specific `invariant`
-    pub fn build_any_location_tree() -> Self {
-        LocationTree {
+    pub fn build_any_location_tree() -> Rc<Self> {
+        Rc::new(LocationTree {
             id: LocationID::AnyLocation,
             invariant: None,
             loc_type: LocationType::Any,
             left: None,
             right: None,
-        }
+        })
     }
 
     //Merge two locations keeping the invariants seperate
-    pub fn merge_as_quotient(left: &Self, right: &Self) -> Self {
+    pub fn merge_as_quotient(left: Rc<Self>, right: Rc<Self>) -> Rc<Self> {
         let id = LocationID::Quotient(Box::new(left.id.clone()), Box::new(right.id.clone()));
 
         let loc_type = left.loc_type.combine(right.loc_type);
 
-        LocationTree {
+        Rc::new(LocationTree {
             id,
             invariant: None,
             loc_type,
-            left: Some(Box::new(left.clone())),
-            right: Some(Box::new(right.clone())),
-        }
+            left: Some(Rc::clone(&left)),
+            right: Some(Rc::clone(&right)),
+        })
     }
 
     //Compose two locations intersecting the invariants
-    pub fn compose(left: &Self, right: &Self, comp: CompositionType) -> Self {
+    pub fn compose(left: Rc<Self>, right: Rc<Self>, comp: CompositionType) -> Rc<Self> {
         let id = match comp {
             CompositionType::Conjunction => {
                 LocationID::Conjunction(Box::new(left.id.clone()), Box::new(right.id.clone()))
@@ -121,13 +123,13 @@ impl LocationTree {
 
         let loc_type = left.loc_type.combine(right.loc_type);
 
-        LocationTree {
+        Rc::new(LocationTree {
             id,
             invariant,
             loc_type,
-            left: Some(Box::new(left.clone())),
-            right: Some(Box::new(right.clone())),
-        }
+            left: Some(Rc::clone(&left)),
+            right: Some(Rc::clone(&right)),
+        })
     }
 
     pub fn get_invariants(&self) -> Option<&OwnedFederation> {
@@ -141,12 +143,12 @@ impl LocationTree {
         fed
     }
 
-    pub fn get_left(&self) -> &LocationTree {
-        self.left.as_ref().unwrap()
+    pub fn get_left(&self) -> Rc<LocationTree> {
+        Rc::clone(self.left.as_ref().unwrap())
     }
 
-    pub fn get_right(&self) -> &LocationTree {
-        self.right.as_ref().unwrap()
+    pub fn get_right(&self) -> Rc<LocationTree> {
+        Rc::clone(self.right.as_ref().unwrap())
     }
 
     pub fn is_initial(&self) -> bool {
@@ -162,7 +164,7 @@ impl LocationTree {
     }
 
     /// This function is used when you want to compare [`LocationTree`]s that can contain partial locations.
-    pub fn compare_partial_locations(&self, other: &LocationTree) -> bool {
+    pub fn compare_partial_locations(&self, other: Rc<LocationTree>) -> bool {
         match (&self.id, &other.id) {
             (LocationID::Composition(..), LocationID::Composition(..))
             | (LocationID::Conjunction(..), LocationID::Conjunction(..))

--- a/src/transition_systems/location_tree.rs
+++ b/src/transition_systems/location_tree.rs
@@ -136,11 +136,12 @@ impl LocationTree {
         self.invariant.as_ref()
     }
 
-    pub fn apply_invariants(&self, mut fed: OwnedFederation) -> OwnedFederation {
+    pub fn apply_invariants(&self, fed: OwnedFederation) -> OwnedFederation {
         if let Some(inv) = &self.invariant {
-            fed = fed.intersection(inv);
+            fed.intersection(inv)
+        } else {
+            fed
         }
-        fed
     }
 
     pub fn get_left(&self) -> Rc<LocationTree> {

--- a/src/transition_systems/quotient.rs
+++ b/src/transition_systems/quotient.rs
@@ -220,6 +220,7 @@ impl TransitionSystem for Quotient {
             }
         }
 
+        let universe = OwnedFederation::universe(self.dim);
         if self.s.get_output_actions().contains(action) {
             // new Rule 3 (includes rule 4 by de-morgan)
             let mut g_s = OwnedFederation::empty(self.dim);
@@ -230,7 +231,7 @@ impl TransitionSystem for Quotient {
             }
 
             // Rule 5 when Rule 3 applies
-            let inv_l_s = loc_s.apply_invariants(OwnedFederation::universe(self.dim));
+            let inv_l_s = loc_s.apply_invariants(universe);
 
             transitions.push(Transition {
                 id: TransitionID::Quotient(Vec::new(), s.iter().map(|t| t.id.clone()).collect()),
@@ -240,7 +241,7 @@ impl TransitionSystem for Quotient {
             });
         } else {
             // Rule 5 when Rule 3 does not apply
-            let inv_l_s = loc_s.apply_invariants(OwnedFederation::universe(self.dim));
+            let inv_l_s = loc_s.apply_invariants(universe);
 
             transitions.push(Transition {
                 id: TransitionID::None,

--- a/src/transition_systems/quotient.rs
+++ b/src/transition_systems/quotient.rs
@@ -220,7 +220,6 @@ impl TransitionSystem for Quotient {
             }
         }
 
-        let universe = OwnedFederation::universe(self.dim);
         if self.s.get_output_actions().contains(action) {
             // new Rule 3 (includes rule 4 by de-morgan)
             let mut g_s = OwnedFederation::empty(self.dim);
@@ -231,7 +230,7 @@ impl TransitionSystem for Quotient {
             }
 
             // Rule 5 when Rule 3 applies
-            let inv_l_s = loc_s.apply_invariants(universe);
+            let inv_l_s = loc_s.apply_invariants(OwnedFederation::universe(self.dim));
 
             transitions.push(Transition {
                 id: TransitionID::Quotient(Vec::new(), s.iter().map(|t| t.id.clone()).collect()),
@@ -241,7 +240,7 @@ impl TransitionSystem for Quotient {
             });
         } else {
             // Rule 5 when Rule 3 does not apply
-            let inv_l_s = loc_s.apply_invariants(universe);
+            let inv_l_s = loc_s.apply_invariants(OwnedFederation::universe(self.dim));
 
             transitions.push(Transition {
                 id: TransitionID::None,

--- a/src/transition_systems/transition_id.rs
+++ b/src/transition_systems/transition_id.rs
@@ -104,8 +104,8 @@ impl TransitionID {
                 paths[component_index].push(
                     transition
                         .iter()
-                        .cloned()
                         .filter(|id| !matches!(id, TransitionID::None))
+                        .cloned()
                         .collect(),
                 );
             }


### PR DESCRIPTION
# Changes

- Added reference counting for `StatePair`, `State`, `LocationTree`.
    - This implementation adds a small overhead that can be detected on very small queries, but gives a substantial performance boost for medium and large queries
    - The primary optimization target for this was the first clone in the `build_state_pair` function, however many other areas are also positively impacted by this implementation.
    - To make use of the reference counting, some methods now take `Rc<T>` as arguments.
- Refactor to use `Rc<OwnedFederation>` instead of `Option<OwnedFederation>` in `State` and `StatePair`.
    - `Option<T>` does not make sense here, since a `StatePair` always has a value
    - Matched naming between `State` and `StatePair` methods for `zone` operations.
    - Avoid weird use of `take_zone`
- Refactor `build_state_pair` to avoid cloning `StatePair`
    - Instead, create the `StatePair` only when needed
    - Avoid unnecessary method `move_locations`
- Remove `prepare_init_state` logic in favor of `StatePair::new`
    - Make logic more clear in `check_refinement`


# Benchmarks
![graph (1)](https://github.com/ECDAR-AAU-SW-P5/Reveaal/assets/33556894/b17f306f-bb14-40bf-a904-5c8064d887e0)

*Bar chart showing the change in percentage for all benchmarks with an absolute change in median measurement higher than 1%. The blue bars indicate the runtime improvement. The red lines indicate the median runtime before optimizations.*

The data from the benchmark can be seen here:

[benchmark-data.json](https://github.com/ECDAR-AAU-SW-P5/Reveaal/files/13546252/benchmark-data.json)


# Memory Profile
A memory profile has been run on the following query:

```
refinement:
(((((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)
<=
(((((Adm2 && HalfAdm1) || Machine || Researcher) && ((Adm2 && HalfAdm2) || Machine || Researcher) && ((HalfAdm1 && HalfAdm2) || Machine || Researcher)) // (Adm2 && HalfAdm1 && HalfAdm2)) // Researcher)
```

With the following results:

|              | Before (bytes) | This PR (bytes)  | Improvement |
| -----------  | -------------- | -------------  | ----------- |
| Total        | 18,255,723,938 | 5,303,956,617  | 70.9%       |
| At `t-gmax`* | 26,302,745     | 14,901,901     | 43.3%       |
| Reads        | 44,058,377,556 | 38,268,545,820 | 13.1%       |
| Writes       | 19,157,637,129 | 6,486,479,520  | 66.1%       |

*At `t-gmax` is the time at which the heap was largest during execution. 

# Tests

- The Kotlin test suite has been run and passed.
- Reveaal tests have been run and passed.